### PR TITLE
Delete all markers from RVizVisualTools

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -200,7 +200,7 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
       namespace.markersById.clear();
     };
 
-    if (ns.length === 0) {
+    if (ns.length === 0 || ns === "deleteAllMarkers") {
       // Delete all markers on this topic
       for (const namespace of this.namespaces.values()) {
         clearNamespace(namespace);


### PR DESCRIPTION
RVizVisualTools sends a "delete all markers" marker with namespace set to `deleteAllMarkers` hence `TopicMarkers` attempts to delete markers in that namespace which has no markers in it while the sender app wants all its markers published by RVizVisualTools to be deleted. 



